### PR TITLE
Implement auto-version parsing for FDM, Ctrls, Gui connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Start FlightGear with `--native-fdm=socket,out,30,localhost,5501,udp --native-fd
 these external commands)
 """
 if __name__ == '__main__':  # NOTE: This is REQUIRED on Windows!
-    fdm_conn = FDMConnection(fdm_version=24)  # May need to change version from 24
+    fdm_conn = FDMConnection()
     fdm_event_pipe = fdm_conn.connect_rx('localhost', 5501, fdm_callback)
     fdm_conn.connect_tx('localhost', 5502)
     fdm_conn.start()  # Start the FDM RX/TX loop
@@ -48,9 +48,9 @@ if __name__ == '__main__':  # NOTE: This is REQUIRED on Windows!
 
 Supported interfaces:
 - [x] [Native Protocol](https://wiki.flightgear.org/Property_Tree/Sockets) (currently only UDP)
-  - [x] Flight Dynamics Model ([`net_fdm.hxx`](https://github.com/FlightGear/flightgear/blob/next/src/Network/net_fdm.hxx))
-  - [x] Controls ([`net_ctrls.hxx`](https://github.com/FlightGear/flightgear/blob/next/src/Network/net_ctrls.hxx))
-  - [x] GUI ([`net_gui.hxx`](https://github.com/FlightGear/flightgear/blob/next/src/Network/net_gui.hxx))
+  - [x] Flight Dynamics Model ([`net_fdm.hxx`](https://github.com/FlightGear/flightgear/blob/next/src/Network/net_fdm.hxx)) version 24, 25
+  - [x] Controls ([`net_ctrls.hxx`](https://github.com/FlightGear/flightgear/blob/next/src/Network/net_ctrls.hxx)) version 27
+  - [x] GUI ([`net_gui.hxx`](https://github.com/FlightGear/flightgear/blob/next/src/Network/net_gui.hxx)) version 8
 - [ ] [Generic Protocol](https://wiki.flightgear.org/Generic_protocol)
 - [x] [Telnet](https://wiki.flightgear.org/Telnet_usage)
 - [x] [HTTP](https://wiki.flightgear.org/Property_Tree_Servers)

--- a/examples/simple_ctrls.py
+++ b/examples/simple_ctrls.py
@@ -30,7 +30,7 @@ def ctrls_callback(ctrls_data, event_pipe):
 Start FlightGear with `--native-ctrls=socket,out,30,localhost,5503,udp --native-ctrls=socket,in,30,localhost,5504,udp`
 """
 if __name__ == '__main__':  # NOTE: This is REQUIRED on Windows!
-    ctrls_conn = CtrlsConnection(ctrls_version=27)
+    ctrls_conn = CtrlsConnection()
     ctrls_event_pipe = ctrls_conn.connect_rx('localhost', 5503, ctrls_callback)
     ctrls_conn.connect_tx('localhost', 5504)
     ctrls_conn.start()  # Start the Ctrls RX/TX loop

--- a/examples/simple_fdm.py
+++ b/examples/simple_fdm.py
@@ -19,7 +19,7 @@ Start FlightGear with `--native-fdm=socket,out,30,localhost,5501,udp --native-fd
 these external commands)
 """
 if __name__ == '__main__':  # NOTE: This is REQUIRED on Windows!
-    fdm_conn = FDMConnection(fdm_version=24)  # May need to change version from 24
+    fdm_conn = FDMConnection()
     fdm_event_pipe = fdm_conn.connect_rx('localhost', 5501, fdm_callback)
     fdm_conn.connect_tx('localhost', 5502)
     fdm_conn.start()  # Start the FDM RX/TX loop

--- a/examples/simple_gui.py
+++ b/examples/simple_gui.py
@@ -16,7 +16,7 @@ def gui_callback(gui_data, event_pipe):
 Start FlightGear with `--native-gui=socket,out,30,localhost,5504,udp --native-gui=socket,in,30,localhost,5505,udp`
 """
 if __name__ == '__main__':  # NOTE: This is REQUIRED on Windows!
-    gui_conn = GuiConnection(gui_version=8)
+    gui_conn = GuiConnection()
     gui_event_pipe = gui_conn.connect_rx('localhost', 5504, gui_callback)
     # Note: I couldn't get FlightGear to do anything with the returned data on this interface
     # I think it's just ignoring everything. Technically you can send data back though.

--- a/examples/simple_wing_level.py
+++ b/examples/simple_wing_level.py
@@ -30,11 +30,11 @@ Start FlightGear with:
 `--native-fdm=socket,out,30,localhost,5501,udp --native-ctrls=socket,out,30,localhost,5503,udp --native-ctrls=socket,in,30,localhost,5504,udp`
 """
 if __name__ == '__main__':  # NOTE: This is REQUIRED on Windows!
-    ctrls_conn = CtrlsConnection(ctrls_version=27)
+    ctrls_conn = CtrlsConnection()
     ctrls_event_pipe = ctrls_conn.connect_rx('localhost', 5503, ctrls_callback)
     ctrls_conn.connect_tx('localhost', 5504)
 
-    fdm_conn = FDMConnection(fdm_version=24)  # May need to change version from 24
+    fdm_conn = FDMConnection()
     fdm_event_pipe = fdm_conn.connect_rx('localhost', 5501, fdm_callback)
 
     ctrls_conn.start()  # Start the Ctrls RX/TX loop

--- a/tests/test_fdm_connection.py
+++ b/tests/test_fdm_connection.py
@@ -7,6 +7,9 @@ import pytest
 
 @pytest.mark.parametrize('fdm_version', supported_fdm_versions)
 def test_fdm_length(mocker, fdm_version):
+    if fdm_version is None:
+        pytest.skip('Testing length makes no sense for auto version')
+
     fdm_length = {
         24: 408,
         25: 552,
@@ -40,6 +43,9 @@ def setup_fdm_mock(mocker, version: int, struct_length: int):
 
 @pytest.mark.parametrize('fdm_version', supported_fdm_versions)
 def test_fdm_rx_and_tx(mocker, fdm_version):
+    if fdm_version is None:
+        pytest.skip('Can\'t generate mocks for auto version')
+
     def rx_cb(fdm_data, event_pipe):
         (run_idx,) = event_pipe.child_recv()
         callback_version = fdm_data['version']
@@ -73,6 +79,9 @@ def test_fdm_rx_and_tx(mocker, fdm_version):
 
 @pytest.mark.parametrize('fdm_version', supported_fdm_versions)
 def test_fdm_only_rx(mocker, fdm_version):
+    if fdm_version is None:
+        pytest.skip('Can\'t generate mocks for auto version')
+
     def rx_cb(fdm_data, event_pipe):
         callback_version = fdm_data['version']
         event_pipe.child_send((callback_version,))

--- a/tests/test_integration_FG_Ctrls.py
+++ b/tests/test_integration_FG_Ctrls.py
@@ -4,10 +4,11 @@ from flightgear_python.fg_if import CtrlsConnection
 
 
 pytestmark = pytest.mark.fg_integration
-ctrls_version = 27  # FlightGear-2020.3.19-x86_64.AppImage
+ctrls_version_and_auto = [None, 27]  # FlightGear-2020.3.19-x86_64.AppImage
 
 
-def test_ctrls_rx_and_tx_integration():
+@pytest.mark.parametrize('ctrls_version', ctrls_version_and_auto)
+def test_ctrls_rx_and_tx_integration(ctrls_version):
     def rx_cb(ctrls_data, event_pipe):
         (run_idx,) = event_pipe.child_recv()
         child_callback_version = ctrls_data['version']
@@ -29,7 +30,8 @@ def test_ctrls_rx_and_tx_integration():
         ctrls_c._fg_packet_roundtrip()
         run_idx, parent_callback_version = ctrls_c.event_pipe.parent_recv()
         assert run_idx == i
-        assert parent_callback_version == ctrls_version
+        if ctrls_version is not None:
+            assert parent_callback_version == ctrls_version
 
     # Prevent 'ResourceWarning: unclosed' warning
     ctrls_c.fg_rx_sock.close()

--- a/tests/test_integration_FG_FDM.py
+++ b/tests/test_integration_FG_FDM.py
@@ -7,16 +7,17 @@ from testing_common import supported_fdm_versions
 
 
 pytestmark = pytest.mark.fg_integration
-fdm_version = 24  # FlightGear-2020.3.19-x86_64.AppImage
+fdm_version_and_auto = [None, 24]  # FlightGear-2020.3.19-x86_64.AppImage
 
 
-def test_fdm_rx_and_tx_integration():
+@pytest.mark.parametrize('fdm_version', fdm_version_and_auto)
+def test_fdm_rx_and_tx_integration(fdm_version):
     def rx_cb(fdm_data, event_pipe):
-        (run_idx,) = event_pipe.child_recv()
+        (run_idx_child,) = event_pipe.child_recv()
         child_callback_version = fdm_data['version']
         event_pipe.child_send(
             (
-                run_idx,
+                run_idx_child,
                 child_callback_version,
             )
         )
@@ -30,16 +31,21 @@ def test_fdm_rx_and_tx_integration():
         fdm_c.event_pipe.parent_send((i,))
         # manually call the process instead of having the process spawn
         fdm_c._fg_packet_roundtrip()
-        run_idx, parent_callback_version = fdm_c.event_pipe.parent_recv()
-        assert run_idx == i
-        assert parent_callback_version == fdm_version
+        run_idx_parent, parent_callback_version = fdm_c.event_pipe.parent_recv()
+        assert run_idx_parent == i
+        if fdm_version is not None:
+            assert parent_callback_version == fdm_version
 
     # Prevent 'ResourceWarning: unclosed' warning
     fdm_c.fg_rx_sock.close()
     fdm_c.fg_tx_sock.close()
 
 
-def test_fdm_wrong_version_in_stream():
+@pytest.mark.parametrize('fdm_version', fdm_version_and_auto)
+def test_fdm_wrong_version_in_stream(fdm_version):
+    if fdm_version is None:
+        pytest.skip('Wrong version test doesn\'t make sense for auto version')
+
     fdm_version_supported_but_not_downloaded = fdm_version + 1
     assert fdm_version_supported_but_not_downloaded in supported_fdm_versions
 

--- a/tests/test_integration_FG_Gui.py
+++ b/tests/test_integration_FG_Gui.py
@@ -4,10 +4,11 @@ from flightgear_python.fg_if import GuiConnection
 
 
 pytestmark = pytest.mark.fg_integration
-gui_version = 8  # FlightGear-2020.3.19-x86_64.AppImage
+gui_version_and_auto = [None, 8]  # FlightGear-2020.3.19-x86_64.AppImage
 
 
-def test_gui_rx_and_tx_integration():
+@pytest.mark.parametrize('gui_version', gui_version_and_auto)
+def test_gui_rx_and_tx_integration(gui_version):
     def rx_cb(gui_data, event_pipe):
         (run_idx,) = event_pipe.child_recv()
         child_callback_version = gui_data['version']
@@ -29,7 +30,8 @@ def test_gui_rx_and_tx_integration():
         gui_c._fg_packet_roundtrip()
         run_idx, parent_callback_version = gui_c.event_pipe.parent_recv()
         assert run_idx == i
-        assert parent_callback_version == gui_version
+        if gui_version is not None:
+            assert parent_callback_version == gui_version
 
     # Prevent 'ResourceWarning: unclosed' warning
     gui_c.fg_rx_sock.close()

--- a/tests/test_integration_JSBSim_fdm.py
+++ b/tests/test_integration_JSBSim_fdm.py
@@ -2,14 +2,24 @@ import math
 
 from flightgear_python.fg_if import FDMConnection
 
-# from testing_common import supported_fdm_versions
+from testing_common import supported_fdm_versions
 from jsbsim_wrapper.jsbsim_wrapper import FlightGearUdpOutput, JsbConfig, Waypoint, setup_jsbsim
-
-import pytest
 
 # TODO: JSBSim 1.1.11 doesn't support FDM v25
 #  Once we drop 3.6 we can fully test v25
-supported_fdm_versions = [24]
+jsb_fg_versions = [24]
+
+
+def pytest_generate_tests(metafunc):
+    test_params = []
+    for supported_fdm_version in supported_fdm_versions:
+        if supported_fdm_version is None:
+            # Special auto-version, should be tested with all available JSB FDM interface versions
+            for jsb_version in jsb_fg_versions:
+                test_params.append((supported_fdm_version, jsb_version))
+        elif supported_fdm_version in jsb_fg_versions:
+            test_params.append((supported_fdm_version, supported_fdm_version))
+    metafunc.parametrize('fdm_version, jsb_fg_version', test_params)
 
 
 def fdm_callback(fdm_data, event_pipe):
@@ -22,9 +32,8 @@ def fdm_callback(fdm_data, event_pipe):
     event_pipe.child_send(child_data)
 
 
-@pytest.mark.parametrize('fdm_version', supported_fdm_versions)
-def test_jsbsim_integration(fdm_version, capsys):
-    fg_to_py_port = 5000 + fdm_version  # So that tests can run parallel
+def test_jsbsim_integration(fdm_version, jsb_fg_version, capsys):
+    fg_to_py_port = 5000 + jsb_fg_version  # So that tests can run parallel
     fdm_conn = FDMConnection(fdm_version=fdm_version)
     fdm_conn.connect_rx('localhost', fg_to_py_port, fdm_callback)
 
@@ -37,7 +46,7 @@ def test_jsbsim_integration(fdm_version, capsys):
             Waypoint(46.765000, 7.626200, 3500),
         ],
         flightgear_outputs=[
-            FlightGearUdpOutput('localhost', fg_to_py_port, update_rate, fg_version=fdm_version),
+            FlightGearUdpOutput('localhost', fg_to_py_port, update_rate, fg_version=jsb_fg_version),
         ],
         time_step=jsb_time_step,
     )
@@ -49,7 +58,7 @@ def test_jsbsim_integration(fdm_version, capsys):
     pos_history = []
     for sim_step_idx in range(total_sim_steps):
         if not jsbfdm.run():
-            print(f'Test ended early {fdm_version}, {sim_step_idx}')
+            print(f'Test ended early {fdm_version}, {jsb_fg_version}, {sim_step_idx}')
             assert False
 
         assert fdm_conn.rx_proc.is_alive()

--- a/tests/testing_common.py
+++ b/tests/testing_common.py
@@ -3,13 +3,16 @@ from pathlib import Path
 
 
 supported_fdm_versions = [
+    None,  # Auto-version
     24,
     25,
 ]
 supported_ctrls_versions = [
+    None,  # Auto-version
     27,
 ]
 supported_gui_versions = [
+    None,  # Auto-version
     8,
 ]
 


### PR DESCRIPTION
Fixes #28 

Implement auto-version detection! Simply don't specify the `version` parameter when creating a `FDMConnection`, `CtrlsConnection`, or `GuiConnection` and have the library auto detect the version during the first Rx loop :smile: 