### PR TITLE
Add integration test to run all example code, enable `rx_proc.daemon`

### DIFF
--- a/examples/simple_gui.py
+++ b/examples/simple_gui.py
@@ -13,14 +13,14 @@ def gui_callback(gui_data, event_pipe):
     event_pipe.child_send(child_data)
 
 """
-Start FlightGear with `--native-gui=socket,out,30,localhost,5504,udp --native-gui=socket,in,30,localhost,5505,udp`
+Start FlightGear with `--native-gui=socket,out,30,localhost,5505,udp --native-gui=socket,in,30,localhost,5506,udp`
 """
 if __name__ == '__main__':  # NOTE: This is REQUIRED on Windows!
     gui_conn = GuiConnection()
-    gui_event_pipe = gui_conn.connect_rx('localhost', 5504, gui_callback)
+    gui_event_pipe = gui_conn.connect_rx('localhost', 5505, gui_callback)
     # Note: I couldn't get FlightGear to do anything with the returned data on this interface
     # I think it's just ignoring everything. Technically you can send data back though.
-    # gui_conn.connect_tx('localhost', 5505)
+    # gui_conn.connect_tx('localhost', 5506)
     gui_conn.start()  # Start the GUI RX loop
 
     while True:

--- a/examples/simple_http.py
+++ b/examples/simple_http.py
@@ -8,9 +8,9 @@ from pprint import pprint
 from flightgear_python.fg_if import HTTPConnection
 
 """
-Start FlightGear with `--httpd=5050`
+Start FlightGear with `--httpd=8080`
 """
-http_conn = HTTPConnection('localhost', 5050)
+http_conn = HTTPConnection('localhost', 8080)
 pprint(http_conn.list_props('/', recurse_limit=0))  # List the top-level properties, no recursion
 while True:
     alt_ft = http_conn.get_prop('/position/altitude-ft')

--- a/flightgear_python/fg_if.py
+++ b/flightgear_python/fg_if.py
@@ -148,6 +148,7 @@ class FGConnection:
         Start the RX/TX loop with FlightGear
         """
         self.rx_proc = mp.Process(target=self._rx_process)
+        self.rx_proc.daemon = True  # rx_proc should exit when parent exits
         self.rx_proc.start()
         _ = self.event_pipe.parent_recv()  # Wait for child to actually run
 

--- a/tests/test_integration_run_examples.py
+++ b/tests/test_integration_run_examples.py
@@ -1,0 +1,24 @@
+import runpy
+import multiprocess as mp
+from pathlib import Path
+
+import pytest
+import _pytest.outcomes
+
+pytestmark = pytest.mark.fg_integration
+
+
+@pytest.mark.timeout(10)  # Examples have infinite loops
+@pytest.mark.parametrize('example_script_path', Path(__file__, '..', '..', 'examples').resolve().glob('*.py'))
+def test_gui_rx_and_tx_integration(example_script_path: Path):
+    try:
+        runpy.run_path(str(example_script_path), run_name='__main__')
+    except _pytest.outcomes.Failed as py_fail:
+        # Timeout is expected, otherwise it's a real error
+        if 'timeout' not in py_fail.msg.lower():
+            raise py_fail
+    # With rx_proc.daemon this isn't strictly necessary, but without manually
+    # calling terminate the callback process still seem to be running. So this
+    # is still a good thing to do.
+    for mp_child in mp.active_children():
+        mp_child.terminate()


### PR DESCRIPTION
Needed to modify some of the example code ports to match up with the integration test script